### PR TITLE
Add lazy Bloom filters testers

### DIFF
--- a/boom/boom.go
+++ b/boom/boom.go
@@ -44,12 +44,16 @@ import (
 // optimal fill ratio
 const fillRatio = 0.5
 
+type FilterTester interface {
+	// Test will test for membership of the data and returns true if it is a
+	// member, false if not.
+	Test(data []byte) bool
+}
+
 // Filter is a probabilistic data structure which is used to test the
 // membership of an element in a set.
 type Filter interface {
-	// Test will test for membership of the data and returns true if it is a
-	// member, false if not.
-	Test([]byte) bool
+	FilterTester
 
 	// Add will add the data to the Bloom filter. It returns the filter to
 	// allow for chaining.

--- a/boom/buckets.go
+++ b/boom/buckets.go
@@ -7,6 +7,10 @@ import (
 	"math/bits"
 )
 
+type BucketGetter interface {
+	Get(bucket uint) uint32
+}
+
 // Buckets is a fast, space-efficient array of buckets where each bucket can
 // store up to a configured maximum value.
 type Buckets struct {
@@ -187,4 +191,36 @@ func (b *Buckets) GobDecode(data []byte) error {
 	_, err := b.ReadFrom(buf)
 
 	return err
+}
+
+type BucketsLazyReader struct {
+	Buckets
+}
+
+// NewBucketsLazyReader creates a new BucketsLazyReader from the provided data
+// and returns the number of bytes used by the Buckets
+// The data is expected to be in the format written by Buckets.WriteTo().
+// Whereas Buckets.ReadFrom() reads the entire data into memory and
+// makes a copy of the data buffer, BucketsLazyReader keeps a reference
+// to the original data buffer and only reads from it when needed.
+func NewBucketsLazyReader(data []byte) (*BucketsLazyReader, int) {
+	bucketSize := data[0]
+
+	// Skip bucketSize (uint8), max (uint8), count (uint64)
+	lenDataOffset := 2*binary.Size(uint8(0)) + binary.Size(uint64(0))
+	// Add len field (uint64(0)) to the above offset
+	dataStart := lenDataOffset + binary.Size(uint64(0))
+	dataEnd := dataStart + int(binary.BigEndian.Uint64(data[lenDataOffset:]))
+
+	return &BucketsLazyReader{
+		Buckets: Buckets{
+			data:       data[dataStart:dataEnd],
+			bucketSize: bucketSize,
+		},
+	}, dataEnd
+}
+
+// Get returns the value in the specified bucket.
+func (s *BucketsLazyReader) Get(bucket uint) uint32 {
+	return s.Buckets.Get(bucket)
 }

--- a/boom/buckets.go
+++ b/boom/buckets.go
@@ -203,7 +203,7 @@ type BucketsLazyReader struct {
 // Whereas Buckets.ReadFrom() reads the entire data into memory and
 // makes a copy of the data buffer, BucketsLazyReader keeps a reference
 // to the original data buffer and only reads from it when needed.
-func NewBucketsLazyReader(data []byte) (*BucketsLazyReader, int) {
+func NewBucketsLazyReader(data []byte) (BucketsLazyReader, int) {
 	bucketSize := data[0]
 
 	// Skip bucketSize (uint8), max (uint8), count (uint64)
@@ -212,7 +212,7 @@ func NewBucketsLazyReader(data []byte) (*BucketsLazyReader, int) {
 	dataStart := lenDataOffset + binary.Size(uint64(0))
 	dataEnd := dataStart + int(binary.BigEndian.Uint64(data[lenDataOffset:]))
 
-	return &BucketsLazyReader{
+	return BucketsLazyReader{
 		Buckets: Buckets{
 			data:       data[dataStart:dataEnd],
 			bucketSize: bucketSize,
@@ -221,6 +221,6 @@ func NewBucketsLazyReader(data []byte) (*BucketsLazyReader, int) {
 }
 
 // Get returns the value in the specified bucket.
-func (s *BucketsLazyReader) Get(bucket uint) uint32 {
+func (s BucketsLazyReader) Get(bucket uint) uint32 {
 	return s.Buckets.Get(bucket)
 }

--- a/boom/buckets_test.go
+++ b/boom/buckets_test.go
@@ -102,6 +102,35 @@ func TestBucketsGob(t *testing.T) {
 	}
 }
 
+func TestBucketsLazyReader(t *testing.T) {
+	filter := NewBuckets(10000, 10)
+	for i := 0; i < 2000; i++ {
+		if i%2 == 0 {
+			filter.Set(uint(i), 1)
+		}
+	}
+
+	buf, err := filter.GobEncode()
+	if err != nil {
+		t.Error(err)
+	}
+
+	lazyFilter, n := NewBucketsLazyReader(buf)
+	if n != len(buf) {
+		t.Errorf("Expected %d bytes read, got %d", len(buf), n)
+	}
+
+	for i := 0; i < 2000; i++ {
+		value := filter.Get(uint(i))
+		lazyValue := lazyFilter.Get(uint(i))
+
+		if value != lazyValue {
+			t.Errorf("Expected %d, got %d for %d", value, lazyValue, i)
+		}
+	}
+
+}
+
 func BenchmarkBucketsIncrement(b *testing.B) {
 	buckets := NewBuckets(10000, 10)
 	for n := 0; n < b.N; n++ {

--- a/boom/partitioned.go
+++ b/boom/partitioned.go
@@ -24,6 +24,10 @@ import (
 	"math"
 )
 
+func getNewHashFunction() hash.Hash64 {
+	return fnv.New64()
+}
+
 // PartitionedBloomFilter implements a variation of a classic Bloom filter as
 // described by Almeida, Baquero, Preguica, and Hutchison in Scalable Bloom
 // Filters:
@@ -59,7 +63,7 @@ func NewPartitionedBloomFilterWithCapacity(m uint, fpRate float64) *PartitionedB
 
 	return &PartitionedBloomFilter{
 		partitions:   partitions,
-		hash:         fnv.New64(),
+		hash:         getNewHashFunction(),
 		m:            m,
 		k:            k,
 		s:            s,
@@ -297,4 +301,66 @@ func (p *PartitionedBloomFilter) GobDecode(data []byte) error {
 	_, err := p.ReadFrom(buf)
 
 	return err
+}
+
+type PartitionedBloomFilterLazyReader struct {
+	partitions []*BucketsLazyReader // partitioned filter data
+	hash       hash.Hash64          // hash function (kernel for all k functions)
+	k          uint                 // number of hash functions (and partitions)
+	s          uint                 // partition size (m / k)
+}
+
+// NewPartitionedBloomFilterLazyReader creates a new PartitionedBloomFilterLazyReader from the provided data
+// and returns the number of bytes used by the PartitionedBloomFilter.
+// The data is expected to be in the format written by PartitionedBloomFilter.WriteTo().
+// Whereas PartitionedBloomFilter.ReadFrom() calls Buckets.ReadFrom() hence making a copy of the data,
+// NewPartitionedBloomFilterLazyReader calls NewBucketsLazyReader which keeps a reference to the original data buffer.
+func NewPartitionedBloomFilterLazyReader(data []byte) (*PartitionedBloomFilterLazyReader, int) {
+	// Skip m (uint64),
+	kOffset := binary.Size(uint64(0))
+	k := binary.BigEndian.Uint64(data[kOffset:])
+
+	// Skip m (uint64), k (uint64),
+	sOffset := 2 * binary.Size(uint64(0))
+	s := binary.BigEndian.Uint64(data[sOffset:])
+
+	// Skip m (uint64), k (uint64), s (uint64), estimatedCount (uint64), optimalCount (uint64)
+	lenBucketsOffset := 5 * binary.Size(uint64(0))
+	lenBuckets := binary.BigEndian.Uint64(data[lenBucketsOffset:])
+
+	bucketStartOffset := lenBucketsOffset + binary.Size(uint64(0))
+
+	partitions := make([]*BucketsLazyReader, lenBuckets)
+	for i := range partitions {
+		b, n := NewBucketsLazyReader(data[bucketStartOffset:])
+		bucketStartOffset += n
+		partitions[i] = b
+	}
+
+	// The length is the bucketStartOffset since we updated it in the last
+	// iteration of the loop above with the length of the last bucket.
+	return &PartitionedBloomFilterLazyReader{
+		partitions: partitions,
+		hash:       getNewHashFunction(),
+		k:          uint(k),
+		s:          uint(s),
+	}, bucketStartOffset
+}
+
+// Test will test for membership of the data and returns true if it is a
+// member, false if not. This is a probabilistic test, meaning there is a
+// non-zero probability of false positives but a zero probability of false
+// negatives. Due to the way the filter is partitioned, the probability of
+// false positives is uniformly distributed across all elements.
+func (p *PartitionedBloomFilterLazyReader) Test(data []byte) bool {
+	lower, upper := hashKernel(data, p.hash)
+
+	// If any of the K partition bits are not set, then it's not a member.
+	for i := uint(0); i < p.k; i++ {
+		if p.partitions[i].Get((uint(lower)+uint(upper)*i)%p.s) == 0 {
+			return false
+		}
+	}
+
+	return true
 }

--- a/boom/partitioned_test.go
+++ b/boom/partitioned_test.go
@@ -158,6 +158,35 @@ func TestPartitionedBloomGob(t *testing.T) {
 	}
 }
 
+func TestPartitionedBloomFilterLazyReader(t *testing.T) {
+	filter := NewPartitionedBloomFilter(100, 0.1)
+	for i := 0; i < 2000; i++ {
+		if i%2 == 0 {
+			filter.Add([]byte(strconv.Itoa(i)))
+		}
+	}
+
+	buf, err := filter.GobEncode()
+	if err != nil {
+		t.Error(err)
+	}
+
+	lazyFilter, n := NewPartitionedBloomFilterLazyReader(buf)
+	if n != len(buf) {
+		t.Errorf("Expected %d bytes read, got %d", len(buf), n)
+	}
+
+	for i := 0; i < 2000; i++ {
+		exists := filter.Test([]byte(strconv.Itoa(i)))
+		lazyExists := lazyFilter.Test([]byte(strconv.Itoa(i)))
+
+		if exists != lazyExists {
+			t.Errorf("Expected %t, got %t for %d", exists, lazyExists, i)
+		}
+	}
+
+}
+
 func BenchmarkPartitionedBloomAdd(b *testing.B) {
 	b.StopTimer()
 	f := NewPartitionedBloomFilter(100000, 0.1)

--- a/boom/partitioned_test.go
+++ b/boom/partitioned_test.go
@@ -166,6 +166,11 @@ func TestPartitionedBloomFilterLazyReader(t *testing.T) {
 		}
 	}
 
+	// We want more than one partition to make sure that we're reading the serialized object correctly.
+	if len(filter.partitions) < 2 {
+		t.Errorf("Expected more than 1 partition, got %d", len(filter.partitions))
+	}
+
 	buf, err := filter.GobEncode()
 	if err != nil {
 		t.Error(err)

--- a/boom/scalable.go
+++ b/boom/scalable.go
@@ -326,8 +326,7 @@ func (s *ScalableBloomFilter) GobDecode(data []byte) error {
 }
 
 type ScalableBloomFilterLazyReader struct {
-	filters     []PartitionedBloomFilterLazyReader
-	initialized bool
+	filters []PartitionedBloomFilterLazyReader
 }
 
 func NewScalableBloomFilterLazyReader(data []byte) (ScalableBloomFilterLazyReader, int) {

--- a/boom/scalable.go
+++ b/boom/scalable.go
@@ -324,3 +324,42 @@ func (s *ScalableBloomFilter) GobDecode(data []byte) error {
 
 	return err
 }
+
+type ScalableBloomFilterLazyReader struct {
+	filters     []*PartitionedBloomFilterLazyReader
+	initialized bool
+}
+
+func NewScalableBloomFilterLazyReader(data []byte) (*ScalableBloomFilterLazyReader, int) {
+	// Skip r, fp, p float64 and hint, s, additionsSinceFillRatioCheck uint64
+	filtersLenOffset := 3*binary.Size(float64(0)) + 3*binary.Size(uint64(0))
+	filtersLen := binary.BigEndian.Uint64(data[filtersLenOffset:])
+
+	filterStartOffset := filtersLenOffset + binary.Size(uint64(0))
+
+	filters := make([]*PartitionedBloomFilterLazyReader, filtersLen)
+	for i := range filters {
+		filter, n := NewPartitionedBloomFilterLazyReader(data[filterStartOffset:])
+		filterStartOffset += n
+		filters[i] = filter
+	}
+
+	return &ScalableBloomFilterLazyReader{
+		filters: filters,
+	}, filterStartOffset
+}
+
+// Test will test for membership of the data and returns true if it is a
+// member, false if not. This is a probabilistic test, meaning there is a
+// non-zero probability of false positives but a zero probability of false
+// negatives.
+func (s *ScalableBloomFilterLazyReader) Test(data []byte) bool {
+	// Querying is made by testing for the presence in each filter.
+	for _, bf := range s.filters {
+		if bf.Test(data) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/boom/scalable_test.go
+++ b/boom/scalable_test.go
@@ -161,6 +161,11 @@ func TestScalableBloomFilterLazyReader(t *testing.T) {
 		}
 	}
 
+	// We want more than one filter to make sure that we're reading the serialized object correctly.
+	if len(filter.filters) < 2 {
+		t.Errorf("Expected more than 1 filter, got %d", len(filter.filters))
+	}
+
 	buf, err := filter.GobEncode()
 	if err != nil {
 		t.Error(err)

--- a/boom/scalable_test.go
+++ b/boom/scalable_test.go
@@ -153,6 +153,35 @@ func TestScalableBloomGob(t *testing.T) {
 	}
 }
 
+func TestScalableBloomFilterLazyReader(t *testing.T) {
+	filter := NewScalableBloomFilter(10, 0.1, 0.8)
+	for i := 0; i < 2000; i++ {
+		if i%2 == 0 {
+			filter.Add([]byte(strconv.Itoa(i)))
+		}
+	}
+
+	buf, err := filter.GobEncode()
+	if err != nil {
+		t.Error(err)
+	}
+
+	lazyFilter, n := NewScalableBloomFilterLazyReader(buf)
+	if n != len(buf) {
+		t.Errorf("Expected %d bytes read, got %d", len(buf), n)
+	}
+
+	for i := 0; i < 2000; i++ {
+		exists := filter.Test([]byte(strconv.Itoa(i)))
+		lazyExists := lazyFilter.Test([]byte(strconv.Itoa(i)))
+
+		if exists != lazyExists {
+			t.Errorf("Expected %t, got %t for %d", exists, lazyExists, i)
+		}
+	}
+
+}
+
 func BenchmarkScalableBloomAdd(b *testing.B) {
 	b.StopTimer()
 	f := NewScalableBloomFilter(100000, 0.1, 0.8)


### PR DESCRIPTION
This PR adds a new set of filter testers that work on top of a data buffer with a serialized filter. 
Contrary to the `ReadFrom` methods of the filters which create copies of the data in the buffer they receive, the new filter testers keep a reference to the original data.